### PR TITLE
Feature/privacy

### DIFF
--- a/contracts/administration/Manager.sol
+++ b/contracts/administration/Manager.sol
@@ -339,7 +339,7 @@ contract Manager is ManagerStorage, Crypto {
    */
   function deploy(
     address payable _owner,
-    address[] memory _heirs,
+    bytes32[] memory _heirs,
     uint256[] memory _dist,
     uint256 _lock,
     address payable _proxy,

--- a/contracts/main/Dethlify.sol
+++ b/contracts/main/Dethlify.sol
@@ -17,14 +17,14 @@ contract Dethlify is BaseStorage, BaseHeader {
    * @notice Construct new Dethlify contract
    * @dev reverts if the distribution does not equal to 100%
    * @param _owner the contract owner
-   * @param _heirs the contract heirs
+   * @param _heirs the hashed contract heirs
    * @param _dist the initial ETH distribution
    * @param _lock the lock period
    * @param _proxy the address of the ManagerProxy
    */
   constructor(
     address payable _owner,
-    address[] memory _heirs,
+    bytes32[] memory _heirs,
     uint256[] memory _dist,
     uint256 _lock,
     address payable _proxy

--- a/contracts/main/modules/BaseHeader.sol
+++ b/contracts/main/modules/BaseHeader.sol
@@ -42,7 +42,7 @@ contract BaseHeader is BaseStorage {
    * @dev Only allow heir for certain actions.
    */
   modifier onlyHeir {
-    require(isHeir[msg.sender], "BH: Only Heir!");
+    require(isHeir[keccak256(abi.encodePacked(msg.sender))], "BH: Only Heir!");
     _;
   }
 
@@ -102,7 +102,7 @@ contract BaseHeader is BaseStorage {
   event WithdrawToken(address indexed heir, address indexed token);
   event StartClaimCycle(address indexed token);
   event ResetClaimCycle(address indexed token);
-  event UpdateDistribution(address[] heirs, uint256[] distributions);
+  event UpdateDistribution(bytes32[] heirs, uint256[] distributions);
   event UpdateTokenDistributions(address[] tokens, uint256[] distributions);
   event UpdateLock(uint256 lock);
   event Pulse();

--- a/contracts/main/modules/BaseStorage.sol
+++ b/contracts/main/modules/BaseStorage.sol
@@ -18,15 +18,15 @@ contract BaseStorage {
   string public version;
   uint256 public paidUntil;
   address payable public owner;
-  address[] public heirs;
+  bytes32[] public heirs;
   uint256 public lock;
   uint256 public last;
-  mapping(address => bool) internal isHeir;
+  mapping(bytes32 => bool) internal isHeir;
   mapping(address => bool) internal tokenIsLocked;
-  mapping(address => mapping(address => bool)) public hasClaimedToken; // [token][heir]
+  mapping(address => mapping(bytes32 => bool)) public hasClaimedToken; // [token][heir]
   mapping(address => uint256) public numHaveClaimedToken;
-  mapping(address => mapping(address => uint256)) public calculatedTokenShares; // [token][heir]
-  mapping(address => mapping(address => uint256)) public tokenDistribution; // [token][heir] = percentage
+  mapping(address => mapping(bytes32 => uint256)) public calculatedTokenShares; // [token][heir]
+  mapping(address => mapping(bytes32 => uint256)) public tokenDistribution; // [token][heir] = percentage
   address[] public setTokens;
   mapping(address => bool) public distributionIsSet;
   uint256 internal day = 24 * 60 * 60;

--- a/migrations/2_deploy_manager_and_proxy.js
+++ b/migrations/2_deploy_manager_and_proxy.js
@@ -1,5 +1,4 @@
 "use strict";
-require("dotenv").config({path: "../.env"});
 const Manager = artifacts.require("Manager");
 const ManagerProxy = artifacts.require("ManagerProxy");
 const IERC20 = artifacts.require("IERC20");

--- a/migrations/4_deploy_dethlify.js
+++ b/migrations/4_deploy_dethlify.js
@@ -19,6 +19,7 @@ module.exports = async (deployer, network, accounts) => {
   const h3 = accounts[3];
   const h4 = accounts[4];
   const heirs = [h1, h2, h3, h4];
+  const hashedHeirs = heirs.map((h) => ethers.utils.solidityKeccak256(["address"], [h]));
   const dist = constants.dethlifyDist;
   let lock = constants.lock;
 
@@ -26,7 +27,7 @@ module.exports = async (deployer, network, accounts) => {
   let manager = await Manager.at(await proxy.getManagerImplementation());
 
   // deploy new contract
-  let transaction = await manager.deploy(dethOwner, heirs, dist, lock, proxy.address, name, nonce, sig, {from: dethOwner, value: ethers.utils.parseEther("100")});
+  let transaction = await manager.deploy(dethOwner, hashedHeirs, dist, lock, proxy.address, name, nonce, sig, {from: dethOwner, value: ethers.utils.parseEther("100")});
 
   let provider = new ethers.providers.JsonRpcProvider("http://localhost:8547");
   let tx = await provider.getTransactionReceipt(transaction.tx);

--- a/test/administration/08-deploy-premium.js
+++ b/test/administration/08-deploy-premium.js
@@ -31,9 +31,10 @@ contract("Manager", async (accounts) => {
     const h3 = accounts[3];
     const h4 = accounts[4];
     const heirs = [h1, h2, h3, h4];
+    const hashedHeirs = heirs.map((h) => ethers.utils.solidityKeccak256(["address"], [h]));
     const dist = constants.dethlifyDist;
 
-    let transaction = await manager.deploy(dethOwner, heirs, dist, lock, proxy.address, name, nonce, sig, {from: dethOwner, value: ethers.utils.parseEther("100")});
+    let transaction = await manager.deploy(dethOwner, hashedHeirs, dist, lock, proxy.address, name, nonce, sig, {from: dethOwner, value: ethers.utils.parseEther("100")});
     let provider = new ethers.providers.JsonRpcProvider("http://localhost:8547");
     let tx = await provider.getTransactionReceipt(transaction.tx);
     let log = tx.logs[tx.logs.length - 1];
@@ -49,7 +50,7 @@ contract("Manager", async (accounts) => {
 
     let isEqual = true;
     for (let i = 0; i < cHeirs.length; i++) {
-      if (cHeirs[i] !== heirs[i]) {
+      if (cHeirs[i] !== hashedHeirs[i]) {
         isEqual = false;
         break;
       }

--- a/test/dethlify/01-constructor.js
+++ b/test/dethlify/01-constructor.js
@@ -13,6 +13,7 @@ contract("Dethlify", async (accounts) => {
   const h3 = accounts[3];
   const h4 = accounts[4];
   const heirs = [h1, h2, h3, h4];
+  const hashedHeirs = heirs.map((h) => ethers.utils.solidityKeccak256(["address"], [h]));
   const dist = constants.dethlifyDist;
   const lock = constants.lock;
   const version = "1.0.0";
@@ -31,7 +32,7 @@ contract("Dethlify", async (accounts) => {
 
     let isEqual = true;
     for (let i = 0; i < cHeirs.length; i++) {
-      if (cHeirs[i] !== heirs[i]) {
+      if (cHeirs[i] !== hashedHeirs[i]) {
         isEqual = false;
         break;
       }

--- a/test/dethlify/07-updateHeirs.js
+++ b/test/dethlify/07-updateHeirs.js
@@ -19,7 +19,7 @@ contract("Dethlify", async (accounts) => {
 
   // POSITIVE
   it("[UPDATEHEIRS] 1.1: Update heirs and distribution", async () => {
-    let NEW_HEIRS = [heir1, heir2];
+    let NEW_HEIRS = [heir1, heir2].map((h) => ethers.utils.solidityKeccak256(["address"], [h]));
     let NEW_DIST = [50 * 100, 50 * 100, 30 * 100, 70 * 100];
     let ETH_DIST = [50 * 100, 50 * 100];
     let DAI_DIST = [30 * 100, 70 * 100];
@@ -63,7 +63,7 @@ contract("Dethlify", async (accounts) => {
   // NEGATIVE
   it("[UPDATEHEIRS] 2.2: Update heirs and distribution as non-owner", async () => {
     try {
-      let NEW_HEIRS = [heir1, heir2];
+      let NEW_HEIRS = [heir1, heir2].map((h) => ethers.utils.solidityKeccak256(["address"], [h]));
       let NEW_DIST = [50 * 100, 50 * 100];
       await dethlify.updateHeirs(NEW_HEIRS, [ETHER], NEW_DIST, {
         from: NOT_OWNER,
@@ -76,7 +76,7 @@ contract("Dethlify", async (accounts) => {
 
   it("[UPDATEHEIRS] 2.2: Update heirs and distribution messed up", async () => {
     try {
-      let NEW_HEIRS = [heir1];
+      let NEW_HEIRS = [heir1].map((h) => ethers.utils.solidityKeccak256(["address"], [h]));
       let NEW_DIST = [50 * 100, 50 * 100];
       await dethlify.updateHeirs(NEW_HEIRS, [ETHER], NEW_DIST, {from: OWNER});
       assert.equal(true, false, "Messed up!");
@@ -97,7 +97,7 @@ contract("Dethlify", async (accounts) => {
   });
 
   it("[UPDATEHEIRS] 2.3: Should have deleted all previous heirs", async () => {
-    let NEW_HEIRS = [heir1, heir2];
+    let NEW_HEIRS = [heir1, heir2].map((h) => ethers.utils.solidityKeccak256(["address"], [h]));
     let NEW_DIST = [50 * 100, 50 * 100];
     await dethlify.updateHeirs(NEW_HEIRS, [ETHER], NEW_DIST, {from: OWNER});
     let dist = await dethlify.tokenDistribution.call(ETHER, accounts[3]);

--- a/utils/sign.js
+++ b/utils/sign.js
@@ -1,5 +1,4 @@
 const ethers = require("ethers");
-require("dotenv").config({path: "../.env"});
 const constants = require("../utils/constants");
 
 async function generateSignature(subdomain, nonce) {


### PR DESCRIPTION
These simple changes make the dethlify contracts fundamentally more private to a certain extend. All heir addresses are now stored using their hashes. The implementation and tests have been adjusted accordingly.

This prevents third parties to get information on the user's heirs. This is until they reveal themselves in the withdrawal process.